### PR TITLE
Financial Remedy iteration 2

### DIFF
--- a/app/assets/sass/application.scss
+++ b/app/assets/sass/application.scss
@@ -42,3 +42,23 @@ mark.comment {
 .jui-measure {
   max-width: 833px;
 }
+
+.jui-case-action-alert {
+  background-color: govuk-colour("bright-red");
+  color: govuk-colour("white");
+  padding: govuk-spacing(4);
+  margin-bottom: govuk-spacing(6);
+}
+
+.jui-case-action-alert h2 {
+  color: govuk-colour("white");
+}
+
+.jui-case-action-alert p {
+  margin-bottom: 0;
+  color: govuk-colour("white");
+}
+
+.jui-case-action-alert a {
+  color: govuk-colour("white");
+}

--- a/app/data/cases.js
+++ b/app/data/cases.js
@@ -6,7 +6,7 @@ module.exports = [
   {
     id: 'FR1231612322',
     typeId: types.fr.id,
-    status: 'Draft consent order submitted',
+    status: '<a href="/app/cases/FR1231612322/documents/1">Review draft consent order</a>',
     applicationDate: moment('2017-11-20 13:01'),
     lastAction: moment('2018-01-25 16:48'),
     tribunalCentre: 'Fox Court',
@@ -20,13 +20,13 @@ module.exports = [
       },
       {
         id: uuid(),
-        date: moment('2018-07-07 13:01'),
-        title: 'D84 submitted',
+        date: moment('2018-05-20 13:01'),
+        title: 'Statement of information (D81) submitted',
         by: 'John Smith'
       },
       {
         id: uuid(),
-        date: moment('2018-07-10 13:01'),
+        date: moment('2018-05-20 13:01'),
         title: 'Form A submitted',
         by: 'John Smith'
       },
@@ -61,13 +61,13 @@ module.exports = [
     ],
     documents: [{
       id: '1',
-      label: 'Consent order'
+      label: 'Draft consent order'
+    }, {
+      id: '3',
+      label: 'Statement of information (D81)'
     }, {
       id: '2',
       label: 'Form A'
-    }, {
-      id: '3',
-      label: 'D81'
     }],
     linkedCases: [{
       type: 'Divorce',
@@ -78,7 +78,7 @@ module.exports = [
   {
     id: 'SC1231612322',
     typeId: types.pip.id,
-    status: 'Deadline expired',
+    status: 'Review case',
     applicationDate: moment('2017-11-20 13:01'),
     lastAction: moment('2018-01-25 16:48'),
     urgent: true,
@@ -273,7 +273,7 @@ module.exports = [
         }
       }
     ],
-    status: 'Party replied',
+    status: 'Review party response',
     applicationDate: moment('2018-05-09'),
     lastAction: moment('2018-05-09'),
     urgent: false,
@@ -342,7 +342,7 @@ module.exports = [
         }
       }
     ],
-    status: 'Consider decree nisi',
+    status: 'Review decree nisi',
     reason: 'Separated for 2 years and consent',
     applicationDate: moment('2018-05-09'),
     documents: [{
@@ -404,7 +404,7 @@ module.exports = [
         }
       }
     ],
-    status: 'Consider decree nisi',
+    status: 'Review decree nisi',
     reason: 'Separated for 2 years and consent',
     applicationDate: moment('2018-05-09'),
     documents: [{

--- a/app/routes/fr.js
+++ b/app/routes/fr.js
@@ -75,10 +75,12 @@ router.get('/app/cases/:id/fr/decision', (req, res) => {
 });
 
 router.post('/app/cases/:id/fr/decision', (req, res) => {
-	if(req.body.decision === 'Approve') {
+	if(req.body.decision === 'Approve consent order') {
 		res.redirect(`/app/cases/${req.params.id}/fr/notes`);
-	} else if(req.body.decision === 'Approve with changes') {
-		res.redirect(`/app/cases/${req.params.id}/fr/upload-1`);
+	} else if(req.body.decision === 'Ask for more information') {
+		res.redirect(`/app/cases/${req.params.id}/fr/more-information`);
+	} else if(req.body.decision === 'List for hearing') {
+		res.redirect(`/app/cases/${req.params.id}/fr/hearing-details`);
 	} else {
 		res.redirect(`/app/cases/${req.params.id}/fr/upload-1`);
 	}
@@ -104,11 +106,11 @@ router.post('/app/cases/:id/fr/upload-1', (req, res) => {
 		res.redirect(`/app/cases/${req.params.id}/fr/upload-2`);
 	} else {
 		switch(req.session.data.decision) {
-			case 'Approve':
-			case 'Approve with changes':
+			case 'Approve consent order':
+			case 'Ask for more information':
 				res.redirect(`/app/cases/${req.params.id}/fr/notes`);
 				break;
-			case 'Reject':
+			case 'Reject consent order':
 				res.redirect(`/app/cases/${req.params.id}/fr/reject-reasons`);
 				break;
 		}
@@ -131,11 +133,30 @@ router.get('/app/cases/:id/fr/upload-2', (req, res) => {
 });
 
 router.post('/app/cases/:id/fr/upload-2', (req, res) => {
-	if(req.session.data.decision === 'Approve with changes') {
+	if(req.session.data.decision === 'Ask for more information') {
 		res.redirect(`/app/cases/${req.params.id}/fr/notes`);
 	} else {
 		res.redirect(`/app/cases/${req.params.id}/fr/reject-reasons`);
 	}
+});
+
+router.get('/app/cases/:id/fr/more-information', (req, res) => {
+  var _case = helpers.getCase(req.session.cases, req.params.id);
+
+	var pageObject = {
+		casebar: helpers.getCaseBarObject(_case),
+		caseActions: helpers.getCaseActions(_case),
+    backLink: {
+      href: `/app/cases/${_case.id}/fr/decision`
+		},
+		_case: _case
+	};
+
+	res.render('app/case/fr/decision/more-information', pageObject);
+});
+
+router.post('/app/cases/:id/fr/more-information', (req, res) => {
+	res.redirect(`/app/cases/${req.params.id}/fr/check`);
 });
 
 router.get('/app/cases/:id/fr/notes', (req, res) => {

--- a/app/routes/fr.js
+++ b/app/routes/fr.js
@@ -159,6 +159,25 @@ router.post('/app/cases/:id/fr/more-information', (req, res) => {
 	res.redirect(`/app/cases/${req.params.id}/fr/check`);
 });
 
+router.get('/app/cases/:id/fr/hearing-details', (req, res) => {
+  var _case = helpers.getCase(req.session.cases, req.params.id);
+
+	var pageObject = {
+		casebar: helpers.getCaseBarObject(_case),
+		caseActions: helpers.getCaseActions(_case),
+    backLink: {
+      href: `/app/cases/${_case.id}/fr/decision`
+		},
+		_case: _case
+	};
+
+	res.render('app/case/fr/decision/hearing-details', pageObject);
+});
+
+router.post('/app/cases/:id/fr/hearing-details', (req, res) => {
+	res.redirect(`/app/cases/${req.params.id}/fr/check`);
+});
+
 router.get('/app/cases/:id/fr/notes', (req, res) => {
   var _case = helpers.getCase(req.session.cases, req.params.id);
 

--- a/app/routes/fr.js
+++ b/app/routes/fr.js
@@ -226,6 +226,10 @@ router.get('/app/cases/:id/fr/check', (req, res) => {
 		reasons: []
 	};
 
+	if(req.session.data.decision === 'List for hearing') {
+		pageObject.backLink.href = `/app/cases/${_case.id}/fr/hearing-details`
+	}
+
 	if(req.session.data.reject) {
 		req.session.data.reject.forEach((item) => {
 			if(item == 'not enough') {

--- a/app/routes/helpers.js
+++ b/app/routes/helpers.js
@@ -46,7 +46,7 @@ function getCaseActions(_case) {
 			return [
 				{
 					href: `/app/cases/${_case.id}/pip/make-decision`,
-					text: 'Make a decision'
+					text: 'Make decision'
 				},
 				{
 					href: `/app/cases/${_case.id}/pip/list-for-hearing`,
@@ -57,14 +57,14 @@ function getCaseActions(_case) {
 			return [
 				{
 					href: `/app/cases/${_case.id}/fr/decision`,
-					text: 'Make a decision'
+					text: 'Make decision'
 				}
 			];
 		case 'divorce':
 			return [
 				{
 					href: `/app/cases/${_case.id}/divorce/make-decision`,
-					text: 'Make a decision'
+					text: 'Make decision'
 				},
 				{
 					href: `/app/cases/${_case.id}/divorce/mark-as-prepared`,

--- a/app/views/app/case/fr/decision/check.html
+++ b/app/views/app/case/fr/decision/check.html
@@ -41,6 +41,105 @@
               </dd>
 
             </div>
+            {% if data.reason %}
+              <div class="app-check-your-answers__contents">
+
+                <dt class="app-check-your-answers__question">Reason for hearing</dt>
+
+                <dd class="app-check-your-answers__answer">
+                  {{data.reason}}
+                </dd>
+
+                <dd class="app-check-your-answers__change">
+                  <a href="/app/cases/{{_case.id}}/fr/hearing-details">Change <span class="govuk-visually-hidden">hearing details</span></a>
+                </dd>
+              </div>
+            {% endif %}
+            {% if data.duration %}
+              <div class="app-check-your-answers__contents">
+
+                <dt class="app-check-your-answers__question">Hearing duration (minutes)</dt>
+
+                <dd class="app-check-your-answers__answer">
+                  {{data.duration}}
+                </dd>
+
+                <dd class="app-check-your-answers__change">
+                  <a href="/app/cases/{{_case.id}}/fr/hearing-details">Change <span class="govuk-visually-hidden">hearing details</span></a>
+                </dd>
+              </div>
+            {% endif %}
+            {% if data['minimum-notice-needed'] %}
+              <div class="app-check-your-answers__contents">
+
+                <dt class="app-check-your-answers__question">Minimum duration needed (working days)</dt>
+
+                <dd class="app-check-your-answers__answer">
+                  {{data['minimum-notice-needed']}}
+                </dd>
+
+                <dd class="app-check-your-answers__change">
+                  <a href="/app/cases/{{_case.id}}/fr/hearing-details">Change <span class="govuk-visually-hidden">hearing details</span></a>
+                </dd>
+              </div>
+            {% endif %}
+
+            {% if data['latest-listing-date-day'] %}
+              <div class="app-check-your-answers__contents">
+
+                <dt class="app-check-your-answers__question">Latest date this can be listed</dt>
+
+                <dd class="app-check-your-answers__answer">
+                  {{data['latest-listing-date-day']}}/{{data['latest-listing-date-month']}}/{{data['latest-listing-date-year']}}
+                </dd>
+
+                <dd class="app-check-your-answers__change">
+                  <a href="/app/cases/{{_case.id}}/fr/hearing-details">Change <span class="govuk-visually-hidden">hearing details</span></a>
+                </dd>
+              </div>
+            {% endif %}
+            {% if data['listed-for-you'] %}
+              <div class="app-check-your-answers__contents">
+
+                <dt class="app-check-your-answers__question">Do you want it to be listed for you?</dt>
+
+                <dd class="app-check-your-answers__answer">
+                  {{data['listed-for-you']}}
+                </dd>
+
+                <dd class="app-check-your-answers__change">
+                  <a href="/app/cases/{{_case.id}}/fr/hearing-details">Change <span class="govuk-visually-hidden">hearing details</span></a>
+                </dd>
+              </div>
+            {% endif %}
+            {% if data['transfer'] %}
+              <div class="app-check-your-answers__contents">
+
+                <dt class="app-check-your-answers__question">Do you want the hearing to be transferred to another court?</dt>
+
+                <dd class="app-check-your-answers__answer">
+                  {{data['transfer']}}
+                </dd>
+
+                <dd class="app-check-your-answers__change">
+                  <a href="/app/cases/{{_case.id}}/fr/hearing-details">Change <span class="govuk-visually-hidden">hearing details</span></a>
+                </dd>
+              </div>
+            {% endif %}
+            {% if data['name-of-court'] %}
+              <div class="app-check-your-answers__contents">
+
+                <dt class="app-check-your-answers__question">Name of court</dt>
+
+                <dd class="app-check-your-answers__answer">
+                  {{data['name-of-court']}}
+                </dd>
+
+                <dd class="app-check-your-answers__change">
+                  <a href="/app/cases/{{_case.id}}/fr/hearing-details">Change <span class="govuk-visually-hidden">hearing details</span></a>
+                </dd>
+              </div>
+            {% endif %}
             {% if reasons.length %}
               <div class="app-check-your-answers__contents">
 
@@ -67,6 +166,7 @@
 
               </div>
             {% endif %}
+
             {% if data['information-needed'] %}
               <div class="app-check-your-answers__contents">
 

--- a/app/views/app/case/fr/decision/check.html
+++ b/app/views/app/case/fr/decision/check.html
@@ -67,17 +67,32 @@
 
               </div>
             {% endif %}
-            <div class="app-check-your-answers__contents">
+            {% if data['information-needed'] %}
+              <div class="app-check-your-answers__contents">
 
-              <dt class="app-check-your-answers__question">Notes</dt>
+                <dt class="app-check-your-answers__question">Information needed</dt>
 
-              <dd class="app-check-your-answers__answer">{{data['decision-notes']}}</dd>
+                <dd class="app-check-your-answers__answer">{{data['information-needed']}}</dd>
 
-              <dd class="app-check-your-answers__change">
-                <a href="/app/cases/{{_case.id}}/fr/decision">Change <span class="govuk-visually-hidden">decision</span></a>
-              </dd>
+                <dd class="app-check-your-answers__change">
+                  <a href="/app/cases/{{_case.id}}/fr/more-information">Change <span class="govuk-visually-hidden">information needed</span></a>
+                </dd>
 
-            </div>
+              </div>
+            {% endif %}
+            {% if data['decision-notes'] %}
+              <div class="app-check-your-answers__contents">
+
+                <dt class="app-check-your-answers__question">Notes</dt>
+
+                <dd class="app-check-your-answers__answer">{{data['decision-notes']}}</dd>
+
+                <dd class="app-check-your-answers__change">
+                  <a href="/app/cases/{{_case.id}}/fr/decision">Change <span class="govuk-visually-hidden">decision</span></a>
+                </dd>
+
+              </div>
+            {% endif %}
 
           </dl>
 

--- a/app/views/app/case/fr/decision/confirmation.html
+++ b/app/views/app/case/fr/decision/confirmation.html
@@ -24,7 +24,7 @@
           {% elseif data.decision == 'Ask for more information' %}
             <p>Your request for more information has been sent to the parties.</p>
           {% elseif data.decision == 'List for hearing' %}
-            <p>TBD</p>
+            <p>Your request has been sent to a court administrator who will list the case for hearing.</p>
           {% elseif data.decision == 'Reject consent order' %}
             <p>Your decision has been sent to a court administrator who will seal the consent order and send it out to the parties.</p>
           {% endif %}

--- a/app/views/app/case/fr/decision/confirmation.html
+++ b/app/views/app/case/fr/decision/confirmation.html
@@ -11,14 +11,11 @@
       <div class="govuk-grid-row">
         <div class="govuk-grid-column-two-thirds">
 
-          <div class="govuk-panel govuk-panel--confirmation">
-            <h2 class="govuk-panel__title">
-              Decision submitted
-            </h2>
-            <div class="govuk-panel__body">
-              {{_case.id}}
-            </div>
-          </div>
+          {{ govukPanel({
+            headingLevel: 1,
+            titleText: "Decision submitted",
+            html: _case.id
+          }) }}
 
           <h2 class="govuk-heading-m">What happens next</h2>
 

--- a/app/views/app/case/fr/decision/confirmation.html
+++ b/app/views/app/case/fr/decision/confirmation.html
@@ -13,25 +13,25 @@
 
           <div class="govuk-panel govuk-panel--confirmation">
             <h2 class="govuk-panel__title">
-              {% if data.decision == 'Approve' %}
-                Consent order approved
-              {% elseif data.decision == 'Approve with changes' %}
-                Consent order approved with changes
-              {% elseif data.decision == 'Reject' %}
-                Consent order rejected
-              {% endif %}
+              Decision submitted
             </h2>
             <div class="govuk-panel__body">
               {{_case.id}}
             </div>
           </div>
 
-          <p>
-            Something here?
-          </p>
-
           <h2 class="govuk-heading-m">What happens next</h2>
-          <p>We’ve sent your decision to admin and it will be issued to the parties involved.</p>
+
+          {% if data.decision == 'Approve consent order' %}
+            <p>Your decision has been sent to a court administrator who will seal the consent order and send it out to the parties.</p>
+          {% elseif data.decision == 'Ask for more information' %}
+            <p>Your request for more information has been sent to the parties.</p>
+          {% elseif data.decision == 'List for hearing' %}
+            <p>TBD</p>
+          {% elseif data.decision == 'Reject consent order' %}
+            <p>Your decision has been sent to a court administrator who will seal the consent order and send it out to the parties.</p>
+          {% endif %}
+
           <p><a href="/app/dashboard">Go to your dashboard</a></p>
 
         </div>

--- a/app/views/app/case/fr/decision/decision.html
+++ b/app/views/app/case/fr/decision/decision.html
@@ -68,26 +68,31 @@ Decision{% endblock %}
               "name": "decision",
               "fieldset": {
                 "legend": {
-                  text: 'Make decision',
+                  text: 'Make a decision',
                   isPageHeading: true,
                   classes: 'govuk-fieldset__legend--l'
                 }
               },
               "items": [
                 {
-                  value: "Approve",
-                  html: "Approve",
-                  checked: checked('decision', "Approve") == 'checked'
+                  value: "Approve consent order",
+                  html: "Approve consent order",
+                  checked: checked('decision', "Approve consent order") == 'checked'
                 },
                 {
-                  value: "Approve with changes",
-                  html: "Approve with changes",
-                  checked: checked('decision', "Approve with changes") == 'checked'
+                  value: "Ask for more information",
+                  html: "Ask for more information",
+                  checked: checked('decision', "Ask for more information") == 'checked'
                 },
                 {
-                  value: "Reject",
-                  html: "Reject",
-                  checked: checked('decision', "Reject") == 'checked'
+                  value: "List for hearing",
+                  html: "List for hearing",
+                  checked: checked('decision', "List for hearing") == 'checked'
+                },
+                {
+                  value: "Reject consent order",
+                  html: "Reject consent order",
+                  checked: checked('decision', "Reject consent order") == 'checked'
                 }
               ]
             }) }}

--- a/app/views/app/case/fr/decision/hearing-details.html
+++ b/app/views/app/case/fr/decision/hearing-details.html
@@ -76,13 +76,16 @@ Hearing details
               },
               items: [
                 {
-                  name: "day"
+                  name: "day",
+                  value: data['latest-listing-date-day']
                 },
                 {
-                  name: "month"
+                  name: "month",
+                  value: data['latest-listing-date-month']
                 },
                 {
-                  name: "year"
+                  name: "year",
+                  value: data['latest-listing-date-year']
                 }
               ]
             }) }}

--- a/app/views/app/case/fr/decision/hearing-details.html
+++ b/app/views/app/case/fr/decision/hearing-details.html
@@ -1,0 +1,167 @@
+{% extends "layouts/admin/base.html" %}
+
+{% block pageTitle %}
+Hearing details
+{% endblock %}
+
+{% block content %}
+
+  {{ juiCasebar({
+    caseId: casebar.id,
+    parties: casebar.parties,
+    caseActions: {
+      actions: caseActions
+    }
+  }) }}
+
+	<div class="jui-width-container">
+
+    {{ govukBackLink({
+      "text": "Back",
+      "href": backLink.href
+    }) }}
+
+    <main class="govuk-main-wrapper" role="main">
+
+        <h1 class="govuk-heading-l">Hearing details</h1>
+
+      <div class="govuk-grid-row">
+        <div class="govuk-grid-column-two-thirds">
+
+          <form method="post">
+
+            {{ govukTextarea({
+              "id": "reason",
+              "name": "reason",
+              "label": {
+                "text": 'Reason',
+                "classes": "govuk-label--m"
+              },
+              value: data['reason']
+            }) }}
+
+            {{ govukInput({
+              id: 'duration',
+              name: 'duration',
+              classes: 'govuk-input--width-5',
+              label: {
+                text: 'Duration (minutes)',
+                classes: 'govuk-label--m'
+              },
+              value: data['duration']
+            }) }}
+
+            {{ govukInput({
+              id: 'minimum-notice-needed',
+              name: 'minimum-notice-needed',
+              classes: 'govuk-input--width-5',
+              label: {
+                text: 'Minimum notice needed (working days)',
+                classes: 'govuk-label--m'
+              },
+              value: data['minimum-notice-needed']
+            }) }}
+
+            {{ govukDateInput({
+              id: "latest-listing-date",
+              name: "latest-listing-date",
+              fieldset: {
+                legend: {
+                  text: "Latest date this can be listed",
+                  classes: "govuk-fieldset__legend--m"
+                }
+              },
+              hint: {
+                text: "For example, 31 3 2018"
+              },
+              items: [
+                {
+                  name: "day"
+                },
+                {
+                  name: "month"
+                },
+                {
+                  name: "year"
+                }
+              ]
+            }) }}
+
+            {{ govukRadios({
+              'idPrefix': "listed-for-you",
+              name: "listed-for-you",
+              classes: "govuk-radios--inline",
+              fieldset: {
+                legend: {
+                  text: 'Do you want it to be listed for you?',
+                  classes: 'govuk-fieldset__legend--m'
+                }
+              },
+              items: [
+                {
+                  value: "Yes",
+                  html: "Yes",
+                  checked: checked('listed-for-you', "Yes") == 'checked'
+                },
+                {
+                  value: "No",
+                  html: "No",
+                  checked: checked('listed-for-you', "No") == 'checked'
+                }
+              ]
+            }) }}
+
+            {% set courtNameInputHtml %}
+              {{ govukInput({
+                id: 'name-of-court',
+                name: 'name-of-court',
+                label: {
+                  text: 'Name of court',
+                  classes: 'govuk-label--m'
+                },
+                value: data['name-of-court']
+              }) }}
+            {% endset %}
+
+            {{ govukRadios({
+              'idPrefix': "transfer",
+              name: "transfer",
+              classes: "govuk-radios--inlin",
+              fieldset: {
+                legend: {
+                  text: 'Do you want the hearing to be transferred to another court?',
+                  classes: 'govuk-fieldset__legend--m'
+                }
+              },
+              items: [
+                {
+                  value: "Yes",
+                  html: "Yes",
+                  checked: checked('transfer', "Yes") == 'checked',
+                  conditional: {
+                    html: courtNameInputHtml
+                  }
+                },
+                {
+                  value: "No",
+                  html: "No",
+                  checked: checked('transfer', "No") == 'checked'
+                }
+              ]
+            }) }}
+
+
+            {{ govukButton({
+              text: "Continue"
+            }) }}
+
+          </form>
+        </div>
+      </div>
+
+		</main>
+
+	</div>
+
+{% endblock %}
+

--- a/app/views/app/case/fr/decision/more-information.html
+++ b/app/views/app/case/fr/decision/more-information.html
@@ -1,0 +1,55 @@
+{% extends "layouts/admin/base.html" %}
+
+{% block pageTitle %}
+More information
+{% endblock %}
+
+{% block content %}
+
+  {{ juiCasebar({
+    caseId: casebar.id,
+    parties: casebar.parties,
+    caseActions: {
+      actions: caseActions
+    }
+  }) }}
+
+	<div class="jui-width-container">
+
+    {{ govukBackLink({
+      "text": "Back",
+      "href": backLink.href
+    }) }}
+
+    <main class="govuk-main-wrapper" role="main">
+
+      <div class="govuk-grid-row">
+        <div class="govuk-grid-column-two-thirds">
+
+          <form method="post">
+
+            {{ govukTextarea({
+              "id": "information-needed",
+              "name": "information-needed",
+              "label": {
+                "text": 'Information needed',
+                "isPageHeading": true,
+                "classes": "govuk-label--l"
+              },
+              value: data['information-needed']
+            }) }}
+
+            {{ govukButton({
+              "text": "Continue"
+            }) }}
+
+          </form>
+        </div>
+      </div>
+
+		</main>
+
+	</div>
+
+{% endblock %}
+

--- a/app/views/app/case/fr/summary.html
+++ b/app/views/app/case/fr/summary.html
@@ -22,6 +22,11 @@
 
     <h1 class="govuk-heading-l">Summary</h1>
 
+    <div class="jui-case-action-alert">
+      <h2 class="govuk-heading-m">Action needed</h2>
+      <p><a href="/app/cases/{{_case.id}}/documents/">Review draft consent order</a></p>
+    </div>
+
     <div class="govuk-grid-row">
 
       <div class="govuk-grid-column-two-thirds">

--- a/app/views/app/case/fr/summary.html
+++ b/app/views/app/case/fr/summary.html
@@ -34,7 +34,7 @@
           "rows": detailsRows
         }) }}
 
-        <h2 class="govuk-heading-m  govuk-!-margin-bottom-2">Linked cases</h2>
+        <h2 class="govuk-heading-m  govuk-!-margin-bottom-2">Related cases</h2>
 
         {{ govukTable({
           "classes": "govuk-!-margin-bottom-7  jui-table  jui-table--fixed",

--- a/app/views/app/dashboard.html
+++ b/app/views/app/dashboard.html
@@ -33,8 +33,8 @@
           {"text": "Case number"},
           {"text": "Parties"},
           {"text": "Type"},
-          {"text": "Status"},
-          {"text": "Start date"},
+          {"text": "Action needed"},
+          {"text": "Case received"},
           {"text": "Date of last event"}
         ],
         "rows": caseList

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "express": "4.15.2",
     "express-session": "^1.13.0",
     "express-writer": "0.0.4",
-    "govuk-frontend": "^1.0.0",
+    "govuk-frontend": "^1.1.0",
     "gulp": "^3.9.1",
     "gulp-clean": "^0.3.2",
     "gulp-mocha": "^4.3.1",


### PR DESCRIPTION
- Changed dashboard status to “Action needed” and made action a link.
- Changed dashboard “Start date” to “Case received”
- Created an action alert component shown on the case summary page.
- Changed “Approve” to “Approve consent order”. Same for “Reject”
- Replaced “Approve with changes” with “Ask for more information” journey”
- Added a “List for hearing” journey
- Improved confirmation content and removed placeholders